### PR TITLE
Fixed stats for D20 & D8

### DIFF
--- a/src/app/servises/items.ts
+++ b/src/app/servises/items.ts
@@ -2089,8 +2089,8 @@ export const itemList: {setName: SetName, items: Item[];}[] = [
           {stat: Stat.POWER, value: 500000},
           {stat: Stat.TOUGHNESS, value: 500000},
           {stat: Stat.ENERGY_CAP, value: 1600},
-          {stat: Stat.ENERGY_POWER, value: 16000},
-          {stat: Stat.ENERGY_BARS, value: 16000},
+          {stat: Stat.ENERGY_POWER, value: 18000},
+          {stat: Stat.ENERGY_BARS, value: 18000},
         ],
       },
       {
@@ -2102,8 +2102,8 @@ export const itemList: {setName: SetName, items: Item[];}[] = [
           {stat: Stat.POWER, value: 500000},
           {stat: Stat.TOUGHNESS, value: 500000},
           {stat: Stat.MAGIC_CAP, value: 1600},
-          {stat: Stat.MAGIC_POWER, value: 16000},
-          {stat: Stat.MAGIC_BARS, value: 16000},
+          {stat: Stat.MAGIC_POWER, value: 18000},
+          {stat: Stat.MAGIC_BARS, value: 18000},
         ],
       },
       {


### PR DESCRIPTION
The stats are currently wrong (should be 18k)

<img width="359" alt="grafik" src="https://user-images.githubusercontent.com/743462/57979965-a9576880-7a24-11e9-9def-f1796f44aec2.png">

<img width="359" alt="grafik" src="https://user-images.githubusercontent.com/743462/57979969-b70cee00-7a24-11e9-9497-5cfac0a9b88f.png">
